### PR TITLE
Research: Birdfy battery telemetry via Tuya API

### DIFF
--- a/docs/birdfy-tuya-findings.md
+++ b/docs/birdfy-tuya-findings.md
@@ -48,7 +48,7 @@ fresh URL via `allocate_rtsp_url()` rather than storing one in config.
 | Pulsar push notifications (`wss://mqe.tuyaus.com:8285/`) | 401 Unauthorized — even after enabling Device Status Notification. Likely not available on free tier or for this device category. |
 | Standard device status (`/v1.0/devices/{id}/status`) | Returns "function not support". `iot-03/.../status` returns empty array. |
 | Device functions / specifications | "not support this device" — Birdfy doesn't expose standard Tuya data points (DPs). |
-| Battery / charge state | Not exposed via any standard API. The device's `status` array is empty. Birdfy keeps power data in its own cloud. |
+| Battery / charge state | See [Battery: revisited](#battery-revisited) below — the data **is** in Tuya cloud, our project just can't see it yet. |
 | Cloud-stored snapshots and clips (the images the Tuya app shows in alerts) | All `/ipc/cloud-storage/...` endpoints return "uri path invalid" — Birdfy stores media in its proprietary cloud, not Tuya's IPC cloud storage. |
 | Camera Service endpoints (`/camera/config`, `/door-bell/screenshot`, etc.) | "uri path invalid" — Birdfy doesn't behave like a standard Tuya IPC. |
 | Device statistics / report-logs | Either "uri path invalid" or "API not subscribed" (requires paid Industry Project Data tier). |
@@ -102,3 +102,85 @@ We do not depend on:
 If Birdfy ever publishes a public API for their own cloud, we could
 optionally fetch their motion-triggered snapshots and AI-detected species
 data, but that's out of scope here.
+
+## Battery: revisited
+
+The original investigation concluded that battery state was simply not
+available. After observing that the Tuya Smart app shows
+**Battery Powered 20%** plus a **Low Battery Alert Threshold** setting on
+the Power Management Settings screen, we know the data definitely lives in
+Tuya cloud — we just weren't asking for it the right way.
+
+### Known Birdfy / `sp_wnq` battery DPs
+
+Reverse-engineered by the
+[`make-all/tuya-local`](https://github.com/make-all/tuya-local/issues/698)
+project from a real BF122-style feeder:
+
+| DP id | Code (best guess) | Type | Notes |
+|-------|-------------------|------|-------|
+| 145 | `battery_percentage` | Integer 0-100 | The 20% the app shows |
+| 146 | `power_supply_mode` | Enum `"0"`/`"1"` | `0`=battery, `1`=AC |
+| 147 | `low_battery_alarm` | Integer 10-30 | The threshold slider |
+| 149 | `device_state` | Bool | dormant / waking |
+| 126 | `battery_report_capacity` | Integer | Sometimes used instead of 145 |
+
+These are **vendor DPs**, not part of any Tuya standard schema. That is the
+root cause of every empty `status` response we saw earlier.
+
+### Why our earlier probes returned empty
+
+Tuya IoT projects have a per-device-type setting called **Control
+Instruction Mode** with two values:
+
+- **Standard Instruction** (default): the cloud only surfaces DPs that
+  match a published standard schema. Vendor DPs are silently filtered out
+  of `/v1.0/devices/{id}/status` and friends. This is what we have now.
+- **DP Instruction**: the cloud surfaces every raw DP the device reports.
+
+To switch it: `iot.tuya.com` → Cloud → Development → *project* → Devices
+tab → pencil-edit the device type → tick **DP Instruction** → save. There
+is no global toggle; it has to be done per device type, and it can take
+several minutes to propagate.
+
+After flipping the toggle, `GET /v1.0/devices/{device_id}/status` should
+start returning entries with codes like `battery_percentage`,
+`power_supply_mode`, `low_battery_alarm`, etc.
+
+### Endpoints worth probing
+
+Even without flipping DP Instruction mode, two newer endpoints sometimes
+expose vendor DPs that the legacy `/v1.0/.../status` route hides:
+
+- `GET /v2.0/cloud/thing/{device_id}/shadow/properties`
+  Smart Home Device Management Service "Query Properties". Returns the
+  latest reported value of every property the cloud has cached for the
+  thing, including custom DPs. Accepts an optional `codes=a,b,c` filter.
+- `GET /v2.0/cloud/thing/{device_id}/model`
+  Returns the data model — useful for confirming which property *codes*
+  this specific device declares before we go hunting for values.
+
+The Power Management API service (which we already have subscribed) also
+documents `GET /v1.0/iot-03/power-devices/{device_id}/balance-charge`
+("Query Remaining Battery Capacity"), but that endpoint is intended for
+energy meters/sub-meters, not IPC cameras — worth a probe but unlikely.
+
+### How to verify locally
+
+`scripts/test_battery3.py` walks all of the above and prints anything that
+looks like battery data. Run it once with the project still in Standard
+Instruction mode to confirm whether the `/v2.0/cloud/thing/.../shadow/...`
+route exposes the DPs without any project changes; if it doesn't, flip the
+device type to DP Instruction mode and re-run.
+
+### Plan once we confirm an endpoint works
+
+1. Add a `TuyaClient.get_battery_state()` method that returns
+   `{percentage: int, power_source: "battery"|"ac", low: bool}`.
+2. Read it from the main loop on a long interval (say once per hour, well
+   inside the rate-limit budget — that's only ~720 calls/month) and log
+   it. Optionally surface it via a future health endpoint.
+3. Update this doc to reflect what actually worked.
+
+We should not bake any of this into the production loop until the probe
+script confirms which endpoint+mode combination this account can use.

--- a/scripts/test_battery3.py
+++ b/scripts/test_battery3.py
@@ -1,0 +1,162 @@
+"""Third attempt at battery info — probe newer Tuya endpoints and known DP IDs.
+
+Findings from external research (April 2026):
+
+* Birdfy / sp_wnq cameras expose battery via these data points:
+    - DP 145  battery_percentage     Integer 0-100
+    - DP 146  power_supply_mode      Enum     "0"=battery / "1"=AC
+    - DP 147  low_battery_alarm      Integer  10-30 threshold
+    - DP 149  device_state           Bool     dormant / waking
+    - DP 126  battery_report_capacity (sometimes used)
+
+* Older /v1.0/devices/{id}/status returned an empty array for us. This is
+  almost always because the IoT project is in "Standard Instruction" mode
+  rather than "DP Instruction" mode. In Standard Instruction mode the cloud
+  only returns DPs that match a published standard schema; Birdfy's vendor
+  DPs are hidden. Switching the device type in the project settings to
+  "DP Instruction" exposes all raw DPs.
+
+* The newer Smart Home Device Management Service exposes DPs as
+  "properties" via /v2.0/cloud/thing/{device_id}/shadow/properties, which
+  appears to bypass the Standard/DP-Instruction toggle for some devices.
+
+This script probes both old and new endpoints and reports anything that
+looks like a battery value, so we can confirm which combination works for
+this account before wiring it into the main service.
+"""
+
+import json
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+from tuya_connector import TuyaOpenAPI
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# DP codes to look for in any response
+BATTERY_CODES = {
+    "battery_percentage",
+    "battery_state",
+    "battery_value",
+    "residual_electricity",
+    "wireless_electricity",
+    "wireless_battery",
+    "wireless_lowpower",
+    "electricity_left",
+    "va_battery",
+    "power_supply_mode",
+    "low_battery_alarm",
+    "battery_report_capacity",
+}
+BATTERY_DP_IDS = {126, 145, 146, 147, 149}
+
+
+def dump(label: str, resp: dict) -> None:
+    logger.info("--- %s ---", label)
+    logger.info("%s", json.dumps(resp, indent=2)[:4000])
+
+
+def main() -> None:
+    load_dotenv()
+
+    access_id = os.environ.get("TUYA_ACCESS_ID", "")
+    access_secret = os.environ.get("TUYA_ACCESS_SECRET", "")
+    device_id = os.environ.get("TUYA_DEVICE_ID", "")
+    if not (access_id and access_secret and device_id):
+        logger.error("Missing TUYA_ACCESS_ID / TUYA_ACCESS_SECRET / TUYA_DEVICE_ID")
+        sys.exit(1)
+
+    api = TuyaOpenAPI("https://openapi.tuyaus.com", access_id, access_secret)
+    if not api.connect().get("success"):
+        logger.error("Tuya connect failed")
+        sys.exit(1)
+
+    # 1. Smart Home Device Management Service — properties shadow.
+    #    This is the newer "things" API. Returns latest reported value of
+    #    every property/DP the cloud knows about, including custom DPs.
+    dump(
+        "v2.0 cloud/thing shadow properties (all)",
+        api.get(f"/v2.0/cloud/thing/{device_id}/shadow/properties"),
+    )
+
+    # 2. Same endpoint, but filtered by codes — saves bandwidth and
+    #    sometimes returns DPs the unfiltered call hides.
+    dump(
+        "v2.0 cloud/thing shadow properties (filtered)",
+        api.get(
+            f"/v2.0/cloud/thing/{device_id}/shadow/properties",
+            params={"codes": ",".join(sorted(BATTERY_CODES))},
+        ),
+    )
+
+    # 3. Data model — tells us what properties this device *should* expose,
+    #    even if their current value is hidden.
+    dump(
+        "v2.0 cloud/thing model",
+        api.get(f"/v2.0/cloud/thing/{device_id}/model"),
+    )
+
+    # 4. Device details (newer endpoint).
+    dump(
+        "v2.0 cloud/thing detail",
+        api.get(f"/v2.0/cloud/thing/{device_id}"),
+    )
+
+    # 5. Power Management Service — Query Remaining Battery Capacity.
+    #    Documented for /v1.0/iot-03/power-devices/{device_id}/balance-charge.
+    #    Almost certainly meant for energy meters, not cameras, but worth
+    #    a probe since the Power Management API service IS subscribed.
+    dump(
+        "Power Management balance-charge",
+        api.get(f"/v1.0/iot-03/power-devices/{device_id}/balance-charge"),
+    )
+
+    # 6. Re-try the legacy status endpoints in case "DP Instruction" mode
+    #    has been toggled on the device type since the last attempt.
+    dump(
+        "v1.0 devices status (after possible DP-Instruction toggle)",
+        api.get(f"/v1.0/devices/{device_id}/status"),
+    )
+    dump(
+        "v1.0 iot-03 devices status",
+        api.get(f"/v1.0/iot-03/devices/{device_id}/status"),
+    )
+
+    # 7. Specifications — lists every DP id/code/type the cloud has on file.
+    dump(
+        "v1.0 iot-03 devices specification",
+        api.get(f"/v1.0/iot-03/devices/{device_id}/specification"),
+    )
+
+    # 8. Hunt for the known battery DP ids in everything we collected. We
+    #    re-issue the shadow query and walk the response so the operator
+    #    sees a clear PASS/FAIL line at the bottom of the run.
+    shadow = api.get(f"/v2.0/cloud/thing/{device_id}/shadow/properties")
+    found = []
+    for prop in (shadow.get("result") or {}).get("properties", []) or []:
+        if (
+            prop.get("dp_id") in BATTERY_DP_IDS
+            or prop.get("code") in BATTERY_CODES
+        ):
+            found.append(prop)
+
+    if found:
+        logger.info("BATTERY DATA FOUND: %s", json.dumps(found, indent=2))
+    else:
+        logger.info(
+            "No battery DPs found. If the Tuya app shows a battery percentage, "
+            "open iot.tuya.com -> Cloud -> your project -> Devices, edit the "
+            "device type for this product, enable 'DP Instruction', save, and "
+            "re-run this script after a few minutes."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The Tuya Smart app shows the camera's battery percentage on the Power Management Settings screen, so the data definitely lives in Tuya cloud even though our earlier probes found nothing. Document the likely cause and add a probe script.

Findings:
- Birdfy / sp_wnq exposes battery as vendor DPs (145 battery_percentage, 146 power_supply_mode, 147 low_battery_alarm, 149 device_state).
- Vendor DPs are filtered out of /v1.0/devices/{id}/status when the project's device type is in "Standard Instruction" mode (the default). Switching the device type to "DP Instruction" mode in iot.tuya.com exposes them.
- /v2.0/cloud/thing/{device_id}/shadow/properties (Smart Home Device Management Service) sometimes exposes vendor DPs without the toggle.

scripts/test_battery3.py probes the new endpoints, the legacy endpoints, and the data model, then reports any battery DPs found so we can confirm which combination works for this account before changing the main loop.

Relates to #1 