### PR TITLE
Capture MP4 clips and post to BirdVision on motion events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ TUYA_DEVICE_ID=your-device-id
 # BIRDCAM_LAT=40.770998606849155
 # BIRDCAM_LON=-73.97321317729947
 # BIRDCAM_RTSP_URL=rtsp://...
+BIRDVISION_API_TOKEN=your-birdvision-api-token
+# BIRDVISION_URL=https://birdvision.example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ RUN uv sync --no-dev --frozen --no-install-project
 
 COPY src/ src/
 
-FROM cgr.dev/chainguard/python:latest
+FROM cgr.dev/chainguard/python:latest-dev
 
-# Keep runtime minimal. The app currently uses opencv-python-headless, so it
-# does not need the optional ffmpeg/libgl runtime packages.
-
+# Install ffmpeg for RTSP clip capture.  The -dev variant is required for apk.
 USER root
+RUN apk add --no-cache ffmpeg
 
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -3,8 +3,7 @@ location:
   lon: -73.97321317729947
 
 capture:
-  fps: 2                        # frames per second during burst
-  duration: 5                   # burst duration in seconds
+  duration: 20                  # clip length in seconds
   rtsp_url: ""                  # leave blank to auto-discover via Tuya API
 
 output:
@@ -14,6 +13,11 @@ polling:
   event_interval: 120           # seconds between event log polls (daylight)
   daylight_check_interval: 300  # seconds between dawn/dusk checks (night)
 
+birdvision:
+  enabled: true
+  url: "https://birdvision.example.com"
+  # api_token set via BIRDVISION_API_TOKEN env var (see .env.example)
+
 # Secrets are loaded from environment variables (or .env file), not this file:
 #   TUYA_ACCESS_ID
 #   TUYA_ACCESS_SECRET
@@ -22,3 +26,5 @@ polling:
 #   BIRDCAM_LAT          (optional, overrides location.lat)
 #   BIRDCAM_LON          (optional, overrides location.lon)
 #   BIRDCAM_RTSP_URL     (optional, overrides capture.rtsp_url)
+#   BIRDVISION_API_TOKEN (secret token for BirdVision API)
+#   BIRDVISION_URL       (optional, overrides birdvision.url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "opencv-python-headless>=4.13.0.92",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
+    "requests>=2.33.1",
     "tuya-connector-python>=0.1.2",
     "tzdata>=2025.3",
 ]

--- a/src/birdcamgrabber/__main__.py
+++ b/src/birdcamgrabber/__main__.py
@@ -4,12 +4,14 @@ import logging
 import queue
 import signal
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
-from .capture import capture_burst
+from .birdvision_client import post_clip
+from .capture import capture_clip
 from .config import load_config
 from .poller import EventPoller
 from .scheduler import is_daylight, log_schedule
@@ -19,6 +21,18 @@ from .tuya_listener import start_listener
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = "config.yaml"
+
+
+def _upload_to_birdvision(clip_path, captured_at, config, event_id):
+    """Run in a background thread so the main poll loop isn't blocked."""
+    post_clip(
+        clip_path,
+        captured_at,
+        config.birdvision,
+        latitude=config.location.lat,
+        longitude=config.location.lon,
+        source_event_id=event_id,
+    )
 
 
 def main() -> None:
@@ -49,6 +63,10 @@ def main() -> None:
         config.polling.event_interval,
         config.polling.daylight_check_interval,
     )
+    if config.birdvision.enabled:
+        logger.info("BirdVision integration enabled: %s", config.birdvision.url)
+    else:
+        logger.info("BirdVision integration disabled")
     log_schedule(config.location)
 
     client: TuyaClient | None = None
@@ -89,8 +107,7 @@ def main() -> None:
                         info.get("online"),
                     )
 
-            # Drain any Pulsar push messages and log them so we can learn
-            # the payload format before using them to trigger captures.
+            # Drain any Pulsar push messages
             while not pulsar_queue.empty():
                 msg = pulsar_queue.get_nowait()
                 logger.info("Pulsar message: %s", msg)
@@ -112,17 +129,30 @@ def main() -> None:
                 now = datetime.now(tz=timezone.utc)
                 event_id = uuid4().hex[:8]
                 date_dir = now.strftime("%Y-%m-%d")
-                burst_dir = now.strftime(f"%H%M%S-{event_id}")
-                output_dir = output_base / date_dir / burst_dir
+                clip_name = now.strftime(f"%H%M%S-{event_id}.mp4")
+                clip_path = output_base / date_dir / clip_name
 
-                # Get a fresh RTSP URL for each burst
+                # Get a fresh RTSP URL for each capture
                 rtsp_url = config.capture.rtsp_url or client.allocate_rtsp_url()
                 if not rtsp_url:
                     logger.error("No RTSP URL available — skipping capture")
                     continue
 
-                frames = capture_burst(rtsp_url, output_dir, config.capture)
-                logger.info("Captured %d frames → %s", len(frames), output_dir)
+                result = capture_clip(rtsp_url, clip_path, config.capture)
+                if result is None:
+                    logger.error("Clip capture failed, skipping BirdVision upload")
+                    continue
+
+                logger.info("Captured clip → %s", clip_path)
+
+                if config.birdvision.enabled:
+                    t = threading.Thread(
+                        target=_upload_to_birdvision,
+                        args=(clip_path, now, config, event_id),
+                        daemon=True,
+                        name=f"bv-upload-{event_id}",
+                    )
+                    t.start()
 
             time.sleep(config.polling.event_interval)
     finally:

--- a/src/birdcamgrabber/birdvision_client.py
+++ b/src/birdcamgrabber/birdvision_client.py
@@ -1,0 +1,84 @@
+"""Client for posting captured clips to BirdVision."""
+
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+from .config import BirdVisionConfig
+
+logger = logging.getLogger(__name__)
+
+_RETRY_DELAYS = (10, 20, 30)  # seconds between attempts
+
+
+def post_clip(
+    clip_path: Path,
+    captured_at: datetime,
+    config: BirdVisionConfig,
+    *,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    source_event_id: str | None = None,
+) -> bool:
+    """POST a video clip to BirdVision's /api/v1/videos endpoint.
+
+    Retries on transient failures with delays of 10 s, 20 s, 30 s before
+    giving up.  Returns True if accepted (202), False after all retries
+    are exhausted.
+    """
+    if not config.enabled:
+        logger.debug("BirdVision integration disabled, skipping upload")
+        return False
+
+    url = config.url.rstrip("/") + "/api/v1/videos"
+    headers = {"X-API-Token": config.api_token}
+    ts = captured_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    data: dict[str, str] = {
+        "captured_at": ts,
+        "source": "birdcamgrabber",
+    }
+    if latitude is not None:
+        data["latitude"] = str(latitude)
+    if longitude is not None:
+        data["longitude"] = str(longitude)
+    if source_event_id:
+        data["source_event_id"] = source_event_id
+
+    for attempt, delay in enumerate((*_RETRY_DELAYS, None), start=1):
+        try:
+            with clip_path.open("rb") as fh:
+                resp = requests.post(
+                    url,
+                    headers=headers,
+                    files={"file": (clip_path.name, fh, "video/mp4")},
+                    data=data,
+                    timeout=60,
+                )
+            if resp.status_code == 202:
+                body = resp.json()
+                logger.info(
+                    "BirdVision accepted clip: job_id=%s url=%s",
+                    body.get("job_id"),
+                    config.url.rstrip("/") + body.get("url", ""),
+                )
+                return True
+            logger.warning(
+                "BirdVision returned %d (attempt %d): %s",
+                resp.status_code,
+                attempt,
+                resp.text[:200],
+            )
+        except requests.RequestException as exc:
+            logger.warning("BirdVision request failed (attempt %d): %s", attempt, exc)
+
+        if delay is None:
+            break
+        logger.info("Retrying BirdVision upload in %ds…", delay)
+        time.sleep(delay)
+
+    logger.error("BirdVision upload failed after %d attempts, giving up", len(_RETRY_DELAYS) + 1)
+    return False

--- a/src/birdcamgrabber/capture.py
+++ b/src/birdcamgrabber/capture.py
@@ -1,59 +1,64 @@
-"""Burst frame capture from an RTSP stream."""
+"""Video clip capture from an RTSP stream."""
 
 import logging
-import time
+import subprocess
 from pathlib import Path
-
-import cv2
 
 from .config import CaptureConfig
 
 logger = logging.getLogger(__name__)
 
 
-def capture_burst(
+def capture_clip(
     rtsp_url: str,
-    output_dir: Path,
+    output_path: Path,
     config: CaptureConfig,
-) -> list[Path]:
-    """Connect to an RTSP stream and capture a burst of frames.
+) -> Path | None:
+    """Capture a video clip from an RTSP stream using ffmpeg.
 
-    Returns a list of paths to saved JPEG files.
+    Saves to ``output_path`` (should end in ``.mp4``).
+    Returns the path on success, ``None`` on failure.
+
+    ffmpeg is preferred over OpenCV's VideoWriter because it can copy the
+    H.264 stream directly from RTSP without re-encoding, which is faster,
+    avoids quality loss, and produces a file BirdVision can play in the
+    browser without a codec warning.
     """
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    cap = cv2.VideoCapture(rtsp_url)
-    if not cap.isOpened():
-        logger.error("Failed to open RTSP stream: %s", rtsp_url)
-        return []
-
-    interval = 1.0 / config.fps
-    total_frames = config.fps * config.duration
-    saved: list[Path] = []
+    cmd = [
+        "ffmpeg",
+        "-loglevel", "warning",
+        "-rtsp_transport", "tcp",
+        "-i", rtsp_url,
+        "-t", str(config.duration),
+        "-c", "copy",          # stream-copy: no re-encode
+        "-movflags", "+faststart",
+        "-y",                  # overwrite if exists
+        str(output_path),
+    ]
 
     logger.info(
-        "Starting burst capture: %d frames at %d fps from %s",
-        total_frames,
-        config.fps,
-        rtsp_url,
+        "Capturing %ds clip from RTSP → %s",
+        config.duration,
+        output_path,
     )
-
     try:
-        for i in range(total_frames):
-            ret, frame = cap.read()
-            if not ret:
-                logger.warning("Stream read failed at frame %d", i + 1)
-                break
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=config.duration + 30)
+    except FileNotFoundError:
+        logger.error("ffmpeg not found — is it installed in the container?")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.error("ffmpeg timed out capturing clip")
+        return None
 
-            frame_path = output_dir / f"frame-{i + 1:03d}.jpg"
-            cv2.imwrite(str(frame_path), frame)
-            saved.append(frame_path)
-            logger.debug("Saved %s", frame_path)
+    if result.returncode != 0:
+        logger.error("ffmpeg failed (rc=%d): %s", result.returncode, result.stderr.strip())
+        return None
 
-            if i < total_frames - 1:
-                time.sleep(interval)
-    finally:
-        cap.release()
+    if not output_path.exists() or output_path.stat().st_size == 0:
+        logger.error("ffmpeg exited cleanly but output file is missing or empty: %s", output_path)
+        return None
 
-    logger.info("Burst complete: %d frames saved to %s", len(saved), output_dir)
-    return saved
+    logger.info("Clip saved: %s (%d bytes)", output_path, output_path.stat().st_size)
+    return output_path

--- a/src/birdcamgrabber/config.py
+++ b/src/birdcamgrabber/config.py
@@ -27,8 +27,7 @@ class LocationConfig:
 
 @dataclass
 class CaptureConfig:
-    fps: int = 2
-    duration: int = 5
+    duration: int = 20      # clip length in seconds
     rtsp_url: str = ""
 
 
@@ -44,12 +43,20 @@ class PollingConfig:
 
 
 @dataclass
+class BirdVisionConfig:
+    enabled: bool = False
+    url: str = ""
+    api_token: str = ""
+
+
+@dataclass
 class AppConfig:
     tuya: TuyaConfig = field(default_factory=TuyaConfig)
     location: LocationConfig = field(default_factory=LocationConfig)
     capture: CaptureConfig = field(default_factory=CaptureConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
     polling: PollingConfig = field(default_factory=PollingConfig)
+    birdvision: BirdVisionConfig = field(default_factory=BirdVisionConfig)
 
 
 def _apply_env_overrides(cfg: AppConfig) -> None:
@@ -70,6 +77,13 @@ def _apply_env_overrides(cfg: AppConfig) -> None:
         cfg.location.timezone = v
     if v := os.environ.get("BIRDCAM_RTSP_URL"):
         cfg.capture.rtsp_url = v
+    if v := os.environ.get("BIRDVISION_URL"):
+        cfg.birdvision.url = v
+        cfg.birdvision.enabled = True
+    if v := os.environ.get("BIRDVISION_API_TOKEN"):
+        cfg.birdvision.api_token = v
+        if cfg.birdvision.url:
+            cfg.birdvision.enabled = True
 
 
 def load_config(path: str | Path) -> AppConfig:
@@ -88,6 +102,7 @@ def load_config(path: str | Path) -> AppConfig:
             capture=CaptureConfig(**raw.get("capture", {})),
             output=OutputConfig(**raw.get("output", {})),
             polling=PollingConfig(**raw.get("polling", {})),
+            birdvision=BirdVisionConfig(**raw.get("birdvision", {})),
         )
         logger.info("Loaded config from %s", path)
 

--- a/src/birdcamgrabber/gallery.py
+++ b/src/birdcamgrabber/gallery.py
@@ -1,12 +1,12 @@
-"""Minimal web gallery for browsing captured bird photos.
+"""Minimal web gallery for browsing captured bird video clips.
 
-Run as `python -m birdcamgrabber.gallery`. Serves images from
+Run as `python -m birdcamgrabber.gallery`. Serves clips from
 ``BIRDCAM_IMAGE_DIR`` (default ``/data/images``) on
 ``BIRDCAM_GALLERY_PORT`` (default 8383).
 
 The directory layout produced by the capture loop is::
 
-    <image_dir>/YYYY-MM-DD/HHMMSS-<event_id>/frame-NNN.jpg
+    <image_dir>/YYYY-MM-DD/HHMMSS-<event_id>.mp4
 """
 
 import logging
@@ -31,14 +31,10 @@ h1 { margin-top: 0; }
 nav { margin-bottom: 1rem; font-size: 0.9rem; }
 ul.list { list-style: none; padding: 0; }
 ul.list li { padding: 0.5rem 0; border-bottom: 1px solid #333; }
-.session { margin-bottom: 2rem; }
-.session h3 { margin: 0 0 0.4rem 0; font-weight: normal; font-size: 0.95rem;
-              color: #aaa; }
-.grid { display: grid; gap: 0.4rem;
-        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
-.grid a { display: block; }
-.grid img { width: 100%; height: 140px; object-fit: cover; border-radius: 4px;
-            background: #222; display: block; }
+.grid { display: grid; gap: 0.75rem;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.clip video { width: 100%; border-radius: 4px; background: #222; display: block; }
+.clip p { margin: 0.3rem 0 0; font-size: 0.85rem; color: #aaa; }
 .empty { color: #888; font-style: italic; }
 """
 
@@ -50,7 +46,7 @@ INDEX_TMPL = """<!doctype html>
 <ul class="list">
 {% for d, count in dates %}
   <li><a href="{{ url_for('date_view', date=d) }}">{{ d }}</a>
-      &mdash; {{ count }} capture{{ '' if count == 1 else 's' }}</li>
+      &mdash; {{ count }} clip{{ '' if count == 1 else 's' }}</li>
 {% endfor %}
 </ul>
 {% else %}
@@ -64,28 +60,25 @@ DATE_TMPL = """<!doctype html>
 <title>{{ date }} &mdash; Birdcam</title><style>{{ css }}</style></head><body>
 <nav><a href="{{ url_for('index') }}">&larr; All dates</a></nav>
 <h1>{{ date }}</h1>
-{% if sessions %}
-{% for session, frames in sessions %}
-<div class="session">
-  <h3>{{ session }} &mdash; {{ frames|length }} frame{{ '' if frames|length == 1 else 's' }}</h3>
-  <div class="grid">
-  {% for f in frames %}
-    <a href="{{ url_for('image', date=date, session=session, frame=f) }}" target="_blank">
-      <img src="{{ url_for('image', date=date, session=session, frame=f) }}" loading="lazy" alt="{{ f }}">
-    </a>
-  {% endfor %}
+{% if clips %}
+<div class="grid">
+{% for clip in clips %}
+  <div class="clip">
+    <video controls preload="metadata">
+      <source src="{{ url_for('clip', date=date, filename=clip) }}" type="video/mp4">
+    </video>
+    <p>{{ clip }}</p>
   </div>
-</div>
 {% endfor %}
+</div>
 {% else %}
-<p class="empty">No captures on this date.</p>
+<p class="empty">No clips on this date.</p>
 {% endif %}
 </body></html>
 """
 
 
 def _safe_child(parent: Path, name: str) -> Path:
-    """Resolve ``parent/name`` and ensure it stays within ``parent``."""
     if "/" in name or "\\" in name or name in ("", ".", ".."):
         abort(404)
     child = (parent / name).resolve()
@@ -104,7 +97,7 @@ def index():
     if IMAGE_DIR.exists():
         for d in sorted(IMAGE_DIR.iterdir(), reverse=True):
             if d.is_dir():
-                count = sum(1 for c in d.iterdir() if c.is_dir())
+                count = sum(1 for f in d.iterdir() if f.suffix.lower() == ".mp4")
                 dates.append((d.name, count))
     return render_template_string(INDEX_TMPL, dates=dates, css=CSS)
 
@@ -114,24 +107,17 @@ def date_view(date: str):
     date_dir = _safe_child(IMAGE_DIR, date)
     if not date_dir.is_dir():
         abort(404)
-    sessions: list[tuple[str, list[str]]] = []
-    for s in sorted(date_dir.iterdir(), reverse=True):
-        if not s.is_dir():
-            continue
-        frames = sorted(
-            f.name for f in s.iterdir()
-            if f.is_file() and f.suffix.lower() in (".jpg", ".jpeg", ".png")
-        )
-        sessions.append((s.name, frames))
-    return render_template_string(DATE_TMPL, date=date, sessions=sessions, css=CSS)
+    clips = sorted(
+        f.name for f in date_dir.iterdir()
+        if f.is_file() and f.suffix.lower() == ".mp4"
+    )
+    return render_template_string(DATE_TMPL, date=date, clips=clips, css=CSS)
 
 
-@app.route("/image/<date>/<session>/<frame>")
-def image(date: str, session: str, frame: str):
+@app.route("/clip/<date>/<filename>")
+def clip(date: str, filename: str):
     date_dir = _safe_child(IMAGE_DIR, date)
-    session_dir = _safe_child(date_dir, session)
-    # send_from_directory itself guards against traversal in `frame`.
-    return send_from_directory(session_dir, frame)
+    return send_from_directory(date_dir, filename)
 
 
 def main() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-04-01T01:04:00.111732Z"
+exclude-newer = "2026-04-01T02:11:03.628268Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -28,6 +28,7 @@ dependencies = [
     { name = "opencv-python-headless" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tuya-connector-python" },
     { name = "tzdata" },
 ]
@@ -39,6 +40,7 @@ requires-dist = [
     { name = "opencv-python-headless", specifier = ">=4.13.0.92" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.33.1" },
     { name = "tuya-connector-python", specifier = ">=0.1.2" },
     { name = "tzdata", specifier = ">=2025.3" },
 ]


### PR DESCRIPTION
Closes #5.

## Summary
- **`capture.py`**: replaced JPG burst with `ffmpeg` stream-copy from RTSP — 20 s clip, no re-encode, `+faststart` for browser playback
- **`birdvision_client.py`**: new module POSTs clip to BirdVision `/api/v1/videos` with `X-API-Token`, lat/lon, `captured_at`, `source_event_id`; retries at 10 s / 20 s / 30 s then gives up; runs in a daemon thread so the poll loop is never blocked
- **`config.py`**: new `BirdVisionConfig` (url, api_token, enabled); loaded from `birdvision:` yaml section and `BIRDVISION_API_TOKEN` / `BIRDVISION_URL` env vars
- **`__main__.py`**: uses `capture_clip`, spawns an upload thread per event
- **`gallery.py`**: rewritten for MP4 — HTML5 `<video controls>` player per clip, date index unchanged
- **`Dockerfile`**: switches runtime to `cgr.dev/chainguard/python:latest-dev`, `apk add ffmpeg`
- **`config.yaml.example`**, **`.env.example`**: document new fields

## Deploy checklist
- [ ] Add `BIRDVISION_API_TOKEN=<token>` to `.env` on the NAS
- [ ] Add `birdvision.url` to `config.yaml` (or set `BIRDVISION_URL` in `.env`)
- [ ] `docker compose build && docker compose up -d`

## Companion
evandhoffman/birdvision#57 (merged) — the BirdVision endpoint this posts to